### PR TITLE
Improve watch logging with timestamps and debug level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +72,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -132,16 +147,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -188,6 +232,12 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -261,6 +311,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -350,6 +406,7 @@ version = "2.1.2"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "clap",
  "clap_lex",
  "dirs",
@@ -484,6 +541,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +593,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -582,6 +673,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -711,6 +811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +923,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1069,6 +1181,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,10 +1260,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools", "command-line-utilities"]
 [dependencies]
 anyhow = "1.0.102"
 axum = "0.8.8"
+chrono = "0.4.44"
 clap = { version = "=4.5.60", features = ["derive", "env"] }
 clap_lex = "=1.0.0"
 dirs = "5"

--- a/src/console.rs
+++ b/src/console.rs
@@ -9,33 +9,39 @@ pub fn log_level() -> u8 {
         .unwrap_or(2)
 }
 
+fn log_with_timestamp(text: impl AsRef<str>) {
+    eprintln!("{} {}",
+        chrono::Local::now().format("%m-%d %H:%M:%S>"),
+        text.as_ref());
+}
+
 /// Print a verbose (level 2) message to stderr when LOGLEVEL >= 2.
 pub fn log_verbose(text: impl AsRef<str>) {
     if log_level() >= 2 {
-        eprintln!("{}", verbose(text));
+        log_with_timestamp(verbose(text));
     }
 }
 
 /// Print an info (level 1) message to stderr when LOGLEVEL >= 1.
 pub fn log_info(text: impl AsRef<str>) {
     if log_level() >= 1 {
-        eprintln!("{}", info(text));
+        log_with_timestamp(info(text));
     }
 }
 
 /// Print a highlight (level 0) message to stderr — always shown.
 pub fn log_highlight(text: impl AsRef<str>) {
-    eprintln!("{}", highlight(text));
+    log_with_timestamp(highlight(text));
 }
 
 /// Print a warning (level 0) message to stderr — always shown.
 pub fn log_warning(text: impl AsRef<str>) {
-    eprintln!("{}", warning(text));
+    log_with_timestamp(warning(text));
 }
 
 /// Print an error (level 0) message to stderr — always shown.
 pub fn log_error(text: impl AsRef<str>) {
-    eprintln!("{}", error(text));
+    log_with_timestamp(error(text));
 }
 
 #[derive(Copy, Clone)]

--- a/src/console.rs
+++ b/src/console.rs
@@ -15,6 +15,13 @@ fn log_with_timestamp(text: impl AsRef<str>) {
         text.as_ref());
 }
 
+/// Print a debug (level 3) message to stderr when LOGLEVEL >= 3.
+pub fn log_debug(text: impl AsRef<str>) {
+    if log_level() >= 3 {
+        log_with_timestamp(debug(text));
+    }
+}
+
 /// Print a verbose (level 2) message to stderr when LOGLEVEL >= 2.
 pub fn log_verbose(text: impl AsRef<str>) {
     if log_level() >= 2 {
@@ -51,6 +58,7 @@ pub enum Color {
     Green,
     Grey,
     Blue,
+    Cyan,
 }
 
 pub fn color_enabled() -> bool {
@@ -79,6 +87,7 @@ pub fn paint(text: impl AsRef<str>, color: Color) -> String {
         Color::Green => 32,
         Color::Grey => 90,
         Color::Blue => 34,
+        Color::Cyan => 36,
     };
 
     format!("\x1b[{code}m{text}\x1b[0m")
@@ -104,6 +113,10 @@ pub fn info(text: impl AsRef<str>) -> String {
     paint(text, Color::Blue)
 }
 
+pub fn debug(text: impl AsRef<str>) -> String {
+    paint(text, Color::Cyan)
+}
+
 pub fn shell_printf(text: &str, color: Option<Color>) -> String {
     let text = text.replace('\'', "'\\''");
     let format = match color.filter(|_| color_enabled()) {
@@ -112,6 +125,7 @@ pub fn shell_printf(text: &str, color: Option<Color>) -> String {
         Some(Color::Green) => "\\033[32m%s\\033[0m\\n",
         Some(Color::Blue) => "\\033[34m%s\\033[0m\\n",
         Some(Color::Grey) => "\\033[90m%s\\033[0m\\n",
+        Some(Color::Cyan) => "\\033[36m%s\\033[0m\\n",
         None => "%s\\n",
     };
 
@@ -126,6 +140,7 @@ pub fn shell_printf_inline(text: &str, color: Option<Color>) -> String {
         Some(Color::Green) => "\\033[32m%s\\033[0m",
         Some(Color::Blue) => "\\033[34m%s\\033[0m",
         Some(Color::Grey) => "\\033[90m%s\\033[0m",
+        Some(Color::Cyan) => "\\033[36m%s\\033[0m",
         None => "%s",
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,16 @@ fn poll_changed_repos(
     let mut changed_repos = HashSet::new();
     let mut failed_repos = HashSet::new();
 
-    if !quiet {
-        console::log_info("checking repos on controller node...");
-    }
-
     let referenced = config.repos_referenced_by_hosts();
+
+    if !quiet {
+        let mut names: Vec<&str> = referenced.iter().map(|s| s.as_str()).collect();
+        names.sort_unstable();
+        console::log_info(format!(
+            "checking repos on controller node: [{}]",
+            names.join(", ")
+        ));
+    }
     let results: Vec<(String, anyhow::Result<String>)> = std::thread::scope(|s| {
         let handles: Vec<_> = config
             .repos

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ fn poll_changed_repos(
                 let repo_name = repo_name.clone();
                 let git_url = repo_def.git_url.clone();
                 if !quiet {
-                    console::log_verbose(format!("checking repo [{}]: {}", repo_name, git_url));
+                    console::log_debug(format!("checking repo [{}]: {}", repo_name, git_url));
                 }
                 s.spawn(move || (repo_name, ops::remote_refs_fingerprint(&git_url)))
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,7 @@ fn run_cycle(
     };
 
     let mut any_host_ran = false;
+    let mut skipped_hosts: Vec<String> = Vec::new();
     std::thread::scope(|s| {
         for (host_id, host) in &config.hosts {
             let host_id = host_id.clone();
@@ -316,10 +317,7 @@ fn run_cycle(
                     &failed_repos,
                 );
                 if !should_run {
-                    console::log_info(format!(
-                        "watch: skip host {{{}}} (no remote repo changes)",
-                        host_id
-                    ));
+                    skipped_hosts.push(host_id.clone());
                 }
                 if has_probe_failure && !first_round && !has_changed_repo && should_run {
                     console::log_warning(format!(
@@ -377,6 +375,13 @@ fn run_cycle(
         }
     });
 
+    if !skipped_hosts.is_empty() {
+        let ids: Vec<_> = skipped_hosts.iter().map(|h| format!("{{{}}}", h)).collect();
+        console::log_info(format!(
+            "watch: skip {} (no remote repo changes)",
+            ids.join(", ")
+        ));
+    }
     if any_host_ran {
         console::log_info(format!("watch: round {} done", round));
     }


### PR DESCRIPTION
## Summary
- Add timestamped console logging and a DEBUG (`LOGLEVEL=3`) log level with cyan output.
- Improve watch-cycle logs by including referenced repo names, compacting skip logs, and moving per-repo polling details to debug level.
- Keep default verbosity cleaner while preserving detailed diagnostics when needed.
