### PR TITLE
Prefer rsync for work copy refresh when available

### DIFF
--- a/core/check-push.sh
+++ b/core/check-push.sh
@@ -141,8 +141,8 @@ function _safe_rm_rf_copies {
 }
 
 # Full refresh: checkout into staging dir, preserve flag files,
-# clean destination contents, move staging contents in, remove staging.
-# actually, to replace the old 'rsync --delete' operation.
+# clean destination contents, sync staging contents in, remove staging.
+# Prefer rsync for syncing when available; fallback to mv.
 function _full_refresh_checkout_branch_into_dir {
   local _br=$1 _cp_path=$2
 
@@ -175,7 +175,11 @@ function _full_refresh_checkout_branch_into_dir {
 
   local _new=("${_staging}"/*)
   (( ${#_new[@]} > 0 )) && {
-     mv -f -- "${_new[@]}" "${_cp_path}/" || warn "..failed to copy-in [${_new[@]}], skipped"
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a -- "${_staging}/" "${_cp_path}/" || warn "..failed to rsync-in [${_staging}], skipped"
+    else
+      mv -f -- "${_new[@]}" "${_cp_path}/" || warn "..failed to copy-in [${_new[@]}], skipped"
+    fi
   }
 
   shopt -u dotglob nullglob


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update full refresh behavior in `core/check-push.sh` to prefer `rsync -a` when `rsync` is installed
- keep existing fallback behavior (`mv` from staging) when `rsync` is not available
- preserve current safety checks and dotfile-preserving cleanup flow

## Why
The work-copy refresh path should prefer `rsync` for checkout-to-work-copy syncing when the command is available.

## Validation
- `bash -n core/check-push.sh`
- `./core/tests/launch-testing.sh` (passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gmicomputing.slack.com/archives/D0AKFAVPR1S/p1775699234681219?thread_ts=1775699234.681219&cid=D0AKFAVPR1S)

<div><a href="https://cursor.com/agents/bc-be939487-dd01-5c2f-a42b-d0632c38ab27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be939487-dd01-5c2f-a42b-d0632c38ab27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

