### PR TITLE
feat: report and retry hard-failed remote repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "git-supervisor"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-supervisor"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2021"
 authors = ["JF Ding <jfding@gmail.com>"]
 description = "Central supervisor to control remote hosts and git repos for deployment"

--- a/core/check-push.sh
+++ b/core/check-push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # LICENSE: MIT
 
-VERSION="2.1.8"
+VERSION="2.1.9"
 
 set -u
 set -o pipefail

--- a/core/check-push.sh
+++ b/core/check-push.sh
@@ -72,9 +72,9 @@ function _logging {
         _line=$(_color_wrap "${_color}" "${_line}")
       fi
       if _color_enabled; then
-        printf '%b\n' "${_line}"
+        printf '%b\n' "${_line}" >&2
       else
-        printf '%s\n' "${_line}"
+        printf '%s\n' "${_line}" >&2
       fi
     fi
 }
@@ -686,7 +686,10 @@ function fetch_and_check {
 function main_loop {
   local _repo
   local _worker_pid
-  local _worker_failed=0
+  local _any_hard_fail
+  local _fail_dir
+  local _f
+  local _failed_repo
 
   cd "$DIR_REPOS" || {
     err "failed to cd to DIR_REPOS: $DIR_REPOS, critical issue, abort"
@@ -695,6 +698,7 @@ function main_loop {
 
   # loop like a daemon
   while true; do
+    _any_hard_fail=0
 
     # Acquire lock
     acquire_lock "${CI_LOCK}" || exit 1
@@ -721,26 +725,46 @@ function main_loop {
       fi
     )
 
+    _fail_dir=$(mktemp -d "${TMPDIR:-/tmp}/gs-fail.XXXXXX") || {
+      err "failed to create FAIL_DIR"; exit 1
+    }
+
     for _repo in $REPOS_TO_CHECK; do
       info "[${_repo}] checking git upstream changes ..."
-      ( LOG_PREFIX="[${_repo}]"; fetch_and_check "${_repo}" ) &
+      (
+        LOG_PREFIX="[${_repo}]"
+        if ! fetch_and_check "${_repo}"; then
+          printf '%s\n' "${_repo}" > "${_fail_dir}/${_repo}"
+          exit 1
+        fi
+      ) &
     done
 
     for _worker_pid in $(jobs -pr); do
-      wait "${_worker_pid}" || _worker_failed=1
+      wait "${_worker_pid}" || _any_hard_fail=1
     done
-    [[ "${_worker_failed}" == "1" ]] && err "one or more repo workers failed in this round"
-    _worker_failed=0
+    for _f in "${_fail_dir}"/*; do
+      [[ -e "$_f" ]] || continue
+      _failed_repo=$(basename "$_f")
+      printf 'result\tfail\t%s\n' "${_failed_repo}"
+      _any_hard_fail=1
+    done
+    rm -rf "${_fail_dir}"
+    [[ "${_any_hard_fail}" == "1" ]] && err "one or more repo workers failed in this round"
 
     # Release lock
     release_lock "${CI_LOCK}"
 
     if [[ "${1:-}" == "once" ]]; then
+      [[ "${_any_hard_fail}" == "1" ]] && exit 1
       exit 0
     fi
 
     # if SLEEP_TIME value is empty or value is 0, means run once and exit
-    [[ $SLEEP_TIME == "" ]] || [[ $SLEEP_TIME == "0" ]] && exit 0
+    [[ $SLEEP_TIME == "" ]] || [[ $SLEEP_TIME == "0" ]] && {
+      [[ "${_any_hard_fail}" == "1" ]] && exit 1
+      exit 0
+    }
 
     info "waiting for next check ..."
     sleep "$SLEEP_TIME"

--- a/core/tests/scripts/test-check-push-result.sh
+++ b/core/tests/scripts/test-check-push-result.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Unit-ish tests for RESULT protocol without full repo fixtures.
+# Sources check-push helpers by running the script in a temp DIR_BASE with a
+# fake broken remote (or mocks fetch_and_check via embedding). Prefer the
+# lightest path that still exercises main_loop's FAIL_DIR + exit path.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/check-push.sh"
+fails=0
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*"; fails=$((fails + 1)); }
+
+# --- parse_result helper exercised against canned stdout ---
+parse_ok=$(printf 'result\tfail\tmy-repo\n' | awk -F'\t' '$1=="result" && $2=="fail" {print $3}')
+[[ "$parse_ok" == "my-repo" ]] && pass "RESULT line shape" || fail "RESULT line shape"
+
+# --- logging goes to stderr ---
+# Extract _logging by running a tiny wrapper: we verify a successful --once
+# with empty REPO_WHITELIST / empty repos still puts no RESULT on stdout.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/git_repos" "$TMP/copies"
+out=$(mktemp); err=$(mktemp)
+set +e
+DIR_BASE="$TMP" SLEEP_TIME=0 CI_LOCK="$TMP/lock.d" LOGLEVEL=1 \
+  bash "$SCRIPT" --once >"$out" 2>"$err"
+rc=$?
+set -e
+[[ $rc -eq 0 ]] && pass "empty run exit 0" || fail "empty run exit 0 (rc=$rc)"
+[[ ! -s "$out" ]] && pass "empty run empty stdout" || fail "empty run stdout not empty: $(cat "$out")"
+# If LOGLEVEL allowed any line, it must be on stderr not stdout — already checked.
+
+# --- hard fail: real git repo with unreachable remote so fetch_and_check returns 1 ---
+git init -q "$TMP/git_repos/badrepo"
+git -C "$TMP/git_repos/badrepo" config user.email "test@test"
+git -C "$TMP/git_repos/badrepo" config user.name "test"
+echo init >"$TMP/git_repos/badrepo/README"
+git -C "$TMP/git_repos/badrepo" add README
+git -C "$TMP/git_repos/badrepo" commit -qm "init"
+git -C "$TMP/git_repos/badrepo" remote add origin "http://127.0.0.1:1/unreachable.git"
+out=$(mktemp); err=$(mktemp)
+set +e
+DIR_BASE="$TMP" SLEEP_TIME=0 CI_LOCK="$TMP/lock.d" LOGLEVEL=0 TIMEOUT=10 \
+  REPO_WHITELIST="badrepo" \
+  bash "$SCRIPT" --once >"$out" 2>"$err"
+rc=$?
+set -e
+[[ $rc -eq 1 ]] && pass "hard fail exit 1" || fail "hard fail exit 1 (rc=$rc)"
+grep -qx $'result\tfail\tbadrepo' "$out" && pass "RESULT for badrepo" || fail "RESULT missing: $(cat "$out")"
+# Human noise must not be on stdout
+! grep -v $'^result\tfail\t' "$out" | grep -q . && pass "stdout only RESULT" || fail "stdout polluted"
+
+[[ $fails -eq 0 ]]

--- a/deployment/docker-compose/compose.yml
+++ b/deployment/docker-compose/compose.yml
@@ -3,7 +3,7 @@
 services:
     loader:
         restart: always
-        image: rushiai/git-supervisor:v2.1.8
+        image: rushiai/git-supervisor:v2.1.9
         volumes:
 
             # if need to handle git repos in localhost, uncomment these two lines

--- a/docs/superpowers/plans/2026-07-23-remote-failed-repos.md
+++ b/docs/superpowers/plans/2026-07-23-remote-failed-repos.md
@@ -1,0 +1,563 @@
+# Remote Failed-Repos Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After each remote `check-push.sh --once` run, the controller learns which repos hard-failed and retries them next cycle (same role as `ls-remote` `failed_repos`).
+
+**Architecture:** Human logs move to stderr; stdout carries only `result\tfail\t<repo>` TSV lines. A new SSH helper inherits stderr (live logs) and captures stdout. `run_check_push_remote` returns `CheckPushReport`. Watch loop keeps host-scoped `deploy_failures` across cycles and unions them into the existing retry/whitelist path.
+
+**Tech Stack:** Bash (`core/check-push.sh`), Rust (`src/ssh.rs`, `src/ops.rs`, `src/lib.rs`). No new crate dependencies. Reuses status/cleanup TSV conventions.
+
+**Spec:** `docs/superpowers/specs/2026-07-23-remote-failed-repos-design.md`
+
+## Global Constraints
+
+- Hard failures only in v1 (`fetch_and_check` `return 1`).
+- Soft failures (copy `continue`, docker ignoring) unchanged — no RESULT lines.
+- RESULT schema: `result<TAB>fail<TAB><repo>` only; no reason column.
+- `--once` exits `1` if any hard fail, else `0`.
+- Live human logs must remain visible (stderr inherit).
+
+---
+
+## File Structure
+
+- **Modify** `core/check-push.sh` — logs → stderr; FAIL_DIR collection; RESULT emission; `--once` exit code.
+- **Create** `core/tests/scripts/test-check-push-result.sh` — shell tests for RESULT + exit + stderr logs.
+- **Modify** `src/ssh.rs` — `ssh_run_inherit_stderr_capture_stdout`.
+- **Modify** `src/ops.rs` — `CheckPushReport`, parse helper, `run_check_push_remote` returns report.
+- **Modify** `src/lib.rs` — `deploy_failures` state through `run_watch` / `run_cycle`.
+
+---
+
+### Task 1: Shell RESULT protocol + stderr logging
+
+**Files:**
+- Modify: `core/check-push.sh`
+- Create: `core/tests/scripts/test-check-push-result.sh`
+
+**Interfaces:**
+- Produces: stdout RESULT lines; stderr human logs; `--once` exit 0/1 as in the spec.
+
+- [ ] **Step 1: Write the failing shell test**
+
+Create `core/tests/scripts/test-check-push-result.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Unit-ish tests for RESULT protocol without full repo fixtures.
+# Sources check-push helpers by running the script in a temp DIR_BASE with a
+# fake broken remote (or mocks fetch_and_check via embedding). Prefer the
+# lightest path that still exercises main_loop's FAIL_DIR + exit path.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/check-push.sh"
+fails=0
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*"; fails=$((fails + 1)); }
+
+# --- parse_result helper exercised against canned stdout ---
+parse_ok=$(printf 'result\tfail\tmy-repo\n' | awk -F'\t' '$1=="result" && $2=="fail" {print $3}')
+[[ "$parse_ok" == "my-repo" ]] && pass "RESULT line shape" || fail "RESULT line shape"
+
+# --- logging goes to stderr ---
+# Extract _logging by running a tiny wrapper: we verify a successful --once
+# with empty REPO_WHITELIST / empty repos still puts no RESULT on stdout.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/git_repos" "$TMP/copies"
+out=$(mktemp); err=$(mktemp)
+set +e
+DIR_BASE="$TMP" SLEEP_TIME=0 CI_LOCK="$TMP/lock.d" LOGLEVEL=1 \
+  bash "$SCRIPT" --once >"$out" 2>"$err"
+rc=$?
+set -e
+[[ $rc -eq 0 ]] && pass "empty run exit 0" || fail "empty run exit 0 (rc=$rc)"
+[[ ! -s "$out" ]] && pass "empty run empty stdout" || fail "empty run stdout not empty: $(cat "$out")"
+# If LOGLEVEL allowed any line, it must be on stderr not stdout — already checked.
+
+# --- hard fail: create a non-git dir named as whitelist repo so fetch path fails,
+#     OR create a git repo with an unreachable remote ---
+mkdir -p "$TMP/git_repos/badrepo"
+# bare incomplete .git so _repo is selected but fetch fails
+mkdir -p "$TMP/git_repos/badrepo/.git"
+out=$(mktemp); err=$(mktemp)
+set +e
+DIR_BASE="$TMP" SLEEP_TIME=0 CI_LOCK="$TMP/lock.d" LOGLEVEL=0 \
+  REPO_WHITELIST="badrepo" \
+  bash "$SCRIPT" --once >"$out" 2>"$err"
+rc=$?
+set -e
+[[ $rc -eq 1 ]] && pass "hard fail exit 1" || fail "hard fail exit 1 (rc=$rc)"
+grep -qx $'result\tfail\tbadrepo' "$out" && pass "RESULT for badrepo" || fail "RESULT missing: $(cat "$out")"
+# Human noise must not be on stdout
+! grep -v $'^result\tfail\t' "$out" | grep -q . && pass "stdout only RESULT" || fail "stdout polluted"
+
+[[ $fails -eq 0 ]]
+```
+
+Make executable. Adjust the “hard fail” fixture if the real script skips incomplete `.git` — the implementer must force a true `fetch_and_check` `return 1` (e.g. real repo + `git remote set-url origin` to `unreachable`).
+
+- [ ] **Step 2: Run test — expect FAIL** (RESULT / exit 1 / stderr not implemented)
+
+```bash
+bash core/tests/scripts/test-check-push-result.sh
+```
+
+Expected: FAIL on hard-fail exit 1 and/or missing RESULT.
+
+- [ ] **Step 3: Implement shell changes**
+
+In `core/check-push.sh`:
+
+1. In `_logging`, after building `_line`, print to stderr:
+
+```bash
+      if _color_enabled; then
+        printf '%b\n' "${_line}" >&2
+      else
+        printf '%s\n' "${_line}" >&2
+      fi
+```
+
+2. In `main_loop`, before the worker spawn loop:
+
+```bash
+    local _fail_dir
+    _fail_dir=$(mktemp -d "${TMPDIR:-/tmp}/gs-fail.XXXXXX") || {
+      err "failed to create FAIL_DIR"; exit 1
+    }
+```
+
+3. Change worker spawn to record failures:
+
+```bash
+    for _repo in $REPOS_TO_CHECK; do
+      info "[${_repo}] checking git upstream changes ..."
+      (
+        LOG_PREFIX="[${_repo}]"
+        if ! fetch_and_check "${_repo}"; then
+          printf '%s\n' "${_repo}" > "${_fail_dir}/${_repo}"
+          exit 1
+        fi
+      ) &
+    done
+```
+
+4. After waits, emit RESULTS and set exit flag; replace the vague-only path:
+
+```bash
+    local _any_hard_fail=0
+    for _worker_pid in $(jobs -pr); do
+      wait "${_worker_pid}" || _any_hard_fail=1
+    done
+    local _f _failed_repo
+    for _f in "${_fail_dir}"/*; do
+      [[ -e "$_f" ]] || continue
+      _failed_repo=$(basename "$_f")
+      printf 'result\tfail\t%s\n' "${_failed_repo}"
+      _any_hard_fail=1
+    done
+    rm -rf "${_fail_dir}"
+    [[ "${_any_hard_fail}" == "1" ]] && err "one or more repo workers failed in this round"
+```
+
+5. `--once` / sleep-0 exit:
+
+```bash
+    if [[ "${1:-}" == "once" ]]; then
+      [[ "${_any_hard_fail}" == "1" ]] && exit 1
+      exit 0
+    fi
+    [[ $SLEEP_TIME == "" ]] || [[ $SLEEP_TIME == "0" ]] && {
+      [[ "${_any_hard_fail}" == "1" ]] && exit 1
+      exit 0
+    }
+```
+
+Ensure `_any_hard_fail` is in scope for those exits (declare at top of the `while` iteration).
+
+- [ ] **Step 4: Re-run shell test — expect PASS**
+
+```bash
+bash core/tests/scripts/test-check-push-result.sh
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/check-push.sh core/tests/scripts/test-check-push-result.sh
+git commit -m "$(cat <<'EOF'
+feat(check-push): emit RESULT TSV for hard-failed repos on stdout
+
+Move human logs to stderr and exit 1 on --once when any worker hard-fails
+so the controller can parse failures without scraping logs.
+EOF
+)"
+```
+
+---
+
+### Task 2: SSH stream helper + RESULT parser
+
+**Files:**
+- Modify: `src/ssh.rs`
+- Modify: `src/ops.rs`
+
+**Interfaces:**
+- Produces:
+  - `ssh::ssh_run_inherit_stderr_capture_stdout(host, command, stdin) -> Result<(ExitStatus, String)>`
+  - `ops::CheckPushReport { failed_repos: Vec<String> }`
+  - `ops::parse_check_push_result(stdout: &str) -> CheckPushReport`
+  - `ops::run_check_push_remote(...) -> Result<CheckPushReport>`
+
+- [ ] **Step 1: Write failing unit tests**
+
+In `src/ops.rs` (or a `#[cfg(test)]` module):
+
+```rust
+#[test]
+fn parse_check_push_result_collects_fail_lines() {
+    let stdout = "result\tfail\trepo-a\nresult\tfail\trepo-b\n";
+    let report = parse_check_push_result(stdout);
+    assert_eq!(report.failed_repos, vec!["repo-a", "repo-b"]);
+}
+
+#[test]
+fn parse_check_push_result_ignores_noise_and_dedups() {
+    let stdout = "hello\nresult\tfail\tx\nresult\tfail\tx\n";
+    let report = parse_check_push_result(stdout);
+    assert_eq!(report.failed_repos, vec!["x"]);
+}
+
+#[test]
+fn parse_check_push_result_empty() {
+    assert!(parse_check_push_result("").failed_repos.is_empty());
+}
+```
+
+In `src/ssh.rs` tests:
+
+```rust
+#[test]
+fn inherit_stderr_capture_stdout_localhost() {
+    let h = host("localhost");
+    let (status, out) = ssh_run_inherit_stderr_capture_stdout(
+        &h,
+        "echo err >&2; echo result$'\t'fail$'\t'r1; exit 1",
+        b"",
+    )
+    .unwrap();
+    assert!(!status.success());
+    assert!(out.contains("result\tfail\tr1"));
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cargo test --lib parse_check_push_result inherit_stderr_capture_stdout -- --nocapture
+```
+
+- [ ] **Step 3: Implement**
+
+`src/ssh.rs`:
+
+```rust
+use std::process::ExitStatus;
+
+/// Pipe stdin; inherit stderr (live logs); capture stdout.
+pub fn ssh_run_inherit_stderr_capture_stdout(
+    host: &Host,
+    command: &str,
+    stdin_data: &[u8],
+) -> Result<(ExitStatus, String)> {
+    let mut cmd = build_ssh_command(host)?;
+    cmd.arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    let mut child = cmd.spawn().context("Failed to execute ssh")?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(stdin_data)
+            .context("Failed to write ssh stdin")?;
+    }
+    let output = child.wait_with_output().context("Failed to wait for ssh")?;
+    // Note: wait_with_output with stderr inherit — verify on localhost that
+    // stderr still streams. If the stdlib requires stderr piped for
+    // wait_with_output, use: take stdout, spawn a reader thread, wait on child.
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    Ok((output.status, stdout))
+}
+```
+
+If `wait_with_output` conflicts with inherited stderr, use explicit:
+
+```rust
+let mut stdout_pipe = child.stdout.take().unwrap();
+let handle = std::thread::spawn(move || {
+    let mut buf = String::new();
+    std::io::Read::read_to_string(&mut stdout_pipe, &mut buf).ok();
+    buf
+});
+// drop stdin already written
+let status = child.wait()?;
+let stdout = handle.join().unwrap_or_default();
+Ok((status, stdout))
+```
+
+`src/ops.rs`:
+
+```rust
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CheckPushReport {
+    pub failed_repos: Vec<String>,
+}
+
+pub fn parse_check_push_result(stdout: &str) -> CheckPushReport {
+    let mut set = std::collections::BTreeSet::new();
+    for line in stdout.lines() {
+        let mut parts = line.split('\t');
+        if parts.next() != Some("result") {
+            continue;
+        }
+        if parts.next() != Some("fail") {
+            continue;
+        }
+        if let Some(repo) = parts.next() {
+            if !repo.is_empty() && parts.next().is_none() {
+                set.insert(repo.to_string());
+            }
+        }
+    }
+    CheckPushReport {
+        failed_repos: set.into_iter().collect(),
+    }
+}
+```
+
+Update `run_check_push_remote` to use the new SSH helper and return `Result<CheckPushReport>`. Map exit codes per spec:
+
+```rust
+pub fn run_check_push_remote(...) -> Result<CheckPushReport> {
+    // ... build command as today ...
+    let (status, stdout) = ssh::ssh_run_inherit_stderr_capture_stdout(host, &command, script.as_bytes())
+        .context("run check-push on remote failed")?;
+    let report = parse_check_push_result(&stdout);
+    if status.success() {
+        return Ok(report);
+    }
+    let code = status.code().unwrap_or(1);
+    if code == 1 {
+        // Caller may expand empty report to full whitelist.
+        return Ok(report);
+    }
+    anyhow::bail!("ssh exited with {}: {}", status, stdout.trim())
+}
+```
+
+Update call sites that expected `Result<()>` to handle `CheckPushReport` (temporary: `let _ = report` until Task 3), or fix compile errors in Task 3 immediately if preferred.
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cargo test --lib parse_check_push_result inherit_stderr_capture_stdout
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ssh.rs src/ops.rs
+git commit -m "$(cat <<'EOF'
+feat: capture check-push RESULT lines while streaming stderr logs
+
+Add ssh_run_inherit_stderr_capture_stdout and parse CheckPushReport from
+result\\tfail\\t<repo> lines.
+EOF
+)"
+```
+
+---
+
+### Task 3: Wire `deploy_failures` into the watch loop
+
+**Files:**
+- Modify: `src/lib.rs`
+
+**Interfaces:**
+- Consumes: `ops::CheckPushReport`, `ops::run_check_push_remote -> Result<CheckPushReport>`
+- Produces: cross-cycle `deploy_failures: HashMap<String, HashSet<String>>` merged into retry/whitelist logic.
+
+- [ ] **Step 1: Write failing unit tests for merge helpers**
+
+Add pure helpers (easy to test) in `src/lib.rs`:
+
+```rust
+fn merge_deploy_failures(
+    deploy_failures: &mut HashMap<String, HashSet<String>>,
+    host_id: &str,
+    whitelist: &HashSet<String>,
+    report: &ops::CheckPushReport,
+    exit_was_fail_with_empty_result: bool,
+) {
+    let entry = deploy_failures.entry(host_id.to_string()).or_default();
+    // Only repos in this run's whitelist (W) are updated.
+    let failed: HashSet<String> = if exit_was_fail_with_empty_result {
+        whitelist.clone()
+    } else {
+        report
+            .failed_repos
+            .iter()
+            .filter(|r| whitelist.contains(*r))
+            .cloned()
+            .collect()
+    };
+    for repo in whitelist {
+        if failed.contains(repo) {
+            entry.insert(repo.clone());
+        } else {
+            entry.remove(repo);
+        }
+    }
+    if entry.is_empty() {
+        deploy_failures.remove(host_id);
+    }
+}
+
+fn failure_set_for_host<'a>(
+    probe_failed: &'a HashSet<String>,
+    deploy_failures: &'a HashMap<String, HashSet<String>>,
+    host_id: &str,
+) -> HashSet<String> {
+    let mut s = probe_failed.clone();
+    if let Some(df) = deploy_failures.get(host_id) {
+        s.extend(df.iter().cloned());
+    }
+    s
+}
+```
+
+Tests:
+
+```rust
+#[test]
+fn merge_deploy_failures_inserts_and_clears() {
+    let mut df = HashMap::new();
+    let wl: HashSet<_> = ["a", "b"].into_iter().map(String::from).collect();
+    let report = ops::CheckPushReport {
+        failed_repos: vec!["a".into()],
+    };
+    merge_deploy_failures(&mut df, "h1", &wl, &report, false);
+    assert_eq!(df.get("h1").unwrap(), &HashSet::from(["a".into()]));
+    let report_ok = ops::CheckPushReport { failed_repos: vec![] };
+    merge_deploy_failures(&mut df, "h1", &wl, &report_ok, false);
+    assert!(df.get("h1").is_none());
+}
+
+#[test]
+fn merge_deploy_failures_empty_result_marks_whitelist() {
+    let mut df = HashMap::new();
+    let wl: HashSet<_> = ["a", "b"].into_iter().map(String::from).collect();
+    let report = ops::CheckPushReport { failed_repos: vec![] };
+    merge_deploy_failures(&mut df, "h1", &wl, &report, true);
+    assert_eq!(df.get("h1").unwrap().len(), 2);
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL** (helpers missing)
+
+```bash
+cargo test --lib merge_deploy_failures -- --nocapture
+```
+
+- [ ] **Step 3: Implement helpers + wire `run_cycle` / `run_watch`**
+
+1. Add `deploy_failures: &mut HashMap<String, HashSet<String>>` param to `run_cycle`.
+2. When computing `failed_repos` for a host, use `failure_set_for_host(&failed_repos, deploy_failures, &host_id)` for `should_run_host_remote` and `effective_filter`.
+3. After `run_check_push_remote`, call `merge_deploy_failures` with the whitelist set actually sent (`effective_filter` or full host repos).
+4. For empty RESULT + exit 1: `run_check_push_remote` should expose whether the report was empty on failure — either return `CheckPushReport` always on exit 1 and let caller check `report.failed_repos.is_empty()`, or add a flag. Spec: empty RESULT + exit 1 → mark all of `W`.
+5. Log warning when host runs due to deploy failures (mirror probe-failure warning).
+6. In `run_watch`, create `let mut deploy_failures = HashMap::new();`, pass through `spawn_blocking` like `last_remote_refs` (take/return both maps).
+
+Thread-scope note: today remote runs are `s.spawn` fire-and-forget. Change to collect reports (e.g. return `(host_id, whitelist, Result<CheckPushReport>)` via channel or scoped join handles) before merging into `deploy_failures` after the scope, **or** use a `Mutex` around `deploy_failures` inside the scope. Prefer collect-then-merge after `thread::scope` for clarity:
+
+```rust
+let mut outcomes = Vec::new();
+std::thread::scope(|s| {
+    // ...
+    s.spawn(|| {
+        let report = ops::run_check_push_remote(...);
+        // send via mpsc or push under Mutex
+    });
+});
+// merge outcomes into deploy_failures
+```
+
+Simplest robust pattern: `Mutex<Vec<(String, HashSet<String>, Result<CheckPushReport>)>>`.
+
+- [ ] **Step 4: Run unit tests + `cargo test --lib`**
+
+```bash
+cargo test --lib merge_deploy_failures
+cargo test --lib
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs src/ops.rs
+git commit -m "$(cat <<'EOF'
+feat(watch): retry repos that hard-failed on remote check-push
+
+Track host-scoped deploy_failures across cycles and union them with
+ls-remote probe failures when deciding remotes and whitelists.
+EOF
+)"
+```
+
+---
+
+### Task 4: Integration smoke (localhost)
+
+**Files:**
+- Create or extend: `tests/integration_ssh.rs` (or new `tests/integration_check_push_result.rs`)
+
+- [ ] **Step 1: Write a localhost test** that runs embedded check-push against a temp `DIR_BASE` with one unreachable-remote repo, asserts `CheckPushReport.failed_repos` contains that repo name, and that a second logical merge leaves it in `deploy_failures`.
+
+If full integration is too heavy for CI, keep the shell test as the primary E2E and add only a Rust test calling `parse_check_push_result` + `merge_deploy_failures` on canned data — do **not** skip Task 1 shell coverage.
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo test --test integration_ssh
+# and/or
+bash core/tests/scripts/test-check-push-result.sh
+```
+
+- [ ] **Step 3: Commit if new test file added**
+
+```bash
+git add tests/
+git commit -m "test: cover check-push RESULT reporting end-to-end"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| Logs → stderr | Task 1 |
+| RESULT TSV on stdout | Task 1 |
+| FAIL_DIR per-worker files | Task 1 |
+| `--once` exit 1 on hard fail | Task 1 |
+| Live stderr inherit + stdout capture | Task 2 |
+| `CheckPushReport` parse | Task 2 |
+| `run_check_push_remote` returns report | Task 2 |
+| `deploy_failures` cross-cycle | Task 3 |
+| Union with probe `failed_repos` | Task 3 |
+| Empty RESULT + exit 1 → mark whitelist | Task 3 |
+| Soft failures unchanged | Task 1 (no code for them) |
+| Shell + Rust tests | Tasks 1–4 |

--- a/docs/superpowers/specs/2026-07-23-remote-failed-repos-design.md
+++ b/docs/superpowers/specs/2026-07-23-remote-failed-repos-design.md
@@ -1,0 +1,192 @@
+# Design: remote hard-fail repo reporting for check-push
+
+Date: 2026-07-23
+
+## Goal
+
+After each remote `check-push.sh --once` run, the controller must know **which
+repos hard-failed**, and retry those repos on the next watch cycle the same way
+it already retries `ls-remote` probe failures (`failed_repos`).
+
+Today the controller only sees a vague host-level outcome (often not even that):
+parallel workers set `_worker_failed=1` and log `"one or more repo workers
+failed"`, `--once` still exits `0`, and `run_check_push_remote` uses
+`ssh_run_with_stdin` (inherit streams, success/fail only).
+
+## Decisions (from brainstorming)
+
+| Topic | Choice |
+|-------|--------|
+| Primary consumer | **Controller retry** (not operator-only logging) |
+| Failure scope (v1) | **Hard failures only** (`return 1` from `fetch_and_check`: invalid name, `cd` fail, `git fetch` fail). Soft failures (copy `continue`, docker “ignoring”) deferred. |
+| Transport | **Approach 2:** human logs on **stderr**, machine RESULT lines on **stdout** |
+| Live logs | Yes — stderr inherited so operators still see streaming output |
+
+## Non-goals (v1)
+
+- Soft-failure reporting (copy / docker)
+- Per-branch or per-tag failure detail
+- JSON payloads
+- Changing daemon-loop control flow beyond emitting RESULT lines each round
+- Reworking `run_check_push_local` retry state (optional reuse of the parser later)
+
+## Wire protocol
+
+### Channels
+
+| Stream | Content |
+|--------|---------|
+| stderr | All human logs (`info` / `warn` / `err` / …) — live via SSH inherit |
+| stdout | Only machine RESULT lines (empty on full success) |
+
+### RESULT schema
+
+One TSV line per hard-failed repo (no header), same spirit as status/cleanup probes:
+
+```text
+result<TAB>fail<TAB><repo>
+```
+
+- Full success → empty stdout, exit `0`.
+- Repo names are already constrained by `_unsafe_path_segment` (no tabs/newlines).
+- No reason column in v1 (may add as column 4 later).
+
+### Exit code (`--once`)
+
+| Code | Meaning |
+|------|---------|
+| `0` | No hard failures |
+| `1` | One or more hard failures (RESULT lines also present when known) |
+| other | Infrastructure abort (lock, missing `DIR_REPOS`, etc.); stdout may be empty |
+
+Daemon mode (no `--once`): emit the same RESULT lines each round; keep looping.
+Exit code only matters for `--once` / the controller.
+
+Standalone operators: logs still appear on a TTY (stderr). Scripts that previously
+captured stdout for “all output” may need `2>&1`.
+
+## `check-push.sh` changes
+
+### Logging
+
+`_logging` (and any other human-facing `printf` that is not a RESULT line) writes
+to **stderr** (`>&2`).
+
+### Parallel-safe failure collection
+
+1. Before spawning workers: create `FAIL_DIR=$(mktemp -d)` (under `$TMPDIR` or
+   adjacent to `CI_LOCK`).
+2. Each background worker: if `fetch_and_check` returns non-zero, write
+   `printf '%s\n' "$_repo" > "$FAIL_DIR/$_repo"` (one file per repo — no
+   concurrent append races).
+3. After all `wait`s: for each file in `FAIL_DIR`, print
+   `result\tfail\t$repo` on **stdout**; remember that hard failures occurred.
+4. `rm -rf "$FAIL_DIR"`.
+5. `--once`: `exit 1` if any hard failure, else `exit 0`.
+
+Hard fail = today’s `return 1` from `fetch_and_check` only.
+
+### Unknown worker failure
+
+If `wait` fails but no file appears in `FAIL_DIR` (e.g. worker killed before
+writing), still treat the round as failed (`exit 1`). The controller then marks
+**all repos in this run’s whitelist** as failed for that host (see below).
+
+## Controller / SSH
+
+### New helper
+
+Alongside `ssh_run_with_stdin` / `ssh_run_capture`:
+
+```text
+ssh_run_stream_result(host, cmd, stdin) -> Result<(exit_status, stdout_string)>
+```
+
+- stderr → inherit (live logs)
+- stdout → piped and fully drained
+- Returns captured stdout and the process exit status (do not auto-bail solely
+  on exit `1` — caller interprets RESULT lines)
+
+Alternatively a thin wrapper that parses immediately; either is fine as long as
+live stderr inherit is preserved.
+
+### Types
+
+```rust
+pub struct CheckPushReport {
+    pub failed_repos: Vec<String>, // sorted, unique
+}
+```
+
+Parser: keep lines matching `^result\tfail\t([^\t]+)$`; ignore anything else on
+stdout (defensive). Drop RESULT repos not in the host’s configured / whitelisted
+set.
+
+### `run_check_push_remote`
+
+Returns `Result<CheckPushReport>` instead of `Result<()>`.
+
+Interpretation:
+
+| Exit | RESULT lines | Outcome |
+|------|--------------|---------|
+| 0 | empty | `Ok(CheckPushReport { failed_repos: [] })` |
+| 1 | non-empty | `Ok(report)` with parsed failures |
+| 1 | empty | Treat as host-level failure: mark **all repos in this run’s whitelist** as failed |
+| SSH/spawn failure | — | `Err(...)` (do not clear prior `deploy_failures` for that host) |
+| other non-zero | — | `Err(...)` or same whitelist-all fallback; prefer `Err` for infra |
+
+`run_check_push_local` may stay fire-and-forget in v1.
+
+## Watch-loop retry wiring
+
+Mirror the cross-cycle role of `last_remote_refs`:
+
+```text
+deploy_failures: HashMap<String /* host_id */, HashSet<String /* repo */>>
+```
+
+Host-scoped: the same repo name can fail on one host and succeed on another.
+
+### Per cycle
+
+1. When building `should_run_host_remote` / `effective_filter`, union this host’s
+   `deploy_failures` with probe `failed_repos` (same path as today).
+2. After each remote run for host `H` with whitelist `W`:
+   - For each repo in `report.failed_repos` ∩ configured repos → insert into
+     `deploy_failures[H]`.
+   - For each repo in `W` that is **not** in `report.failed_repos` and the run
+     was a parseable success/fail report → remove from `deploy_failures[H]`
+     (cleared on successful deploy attempt).
+   - Empty-stdout + exit 1 → insert all of `W` into `deploy_failures[H]`.
+3. Log a warning when a host runs solely (or partly) because of deploy failures,
+   analogous to the existing “probe failures” warning.
+
+Webhook / first round: still send the full whitelist; still update
+`deploy_failures` from the report so the next timer round can narrow retries.
+
+`deploy_failures` lives in `run_watch` and is passed into / returned from
+`run_cycle` the same way as `last_remote_refs`.
+
+## Edge cases
+
+| Case | Behavior |
+|------|----------|
+| RESULT repo not in config | Ignore line |
+| Concurrent hosts | Independent SSH sessions; no shared remote state |
+| Empty whitelist / no repos | No RESULT, exit 0 |
+| Soft failures | Unchanged; do not write FAIL_DIR / RESULT |
+
+## Testing
+
+- **Shell:** force a hard fail → RESULT line on stdout + exit 1; all ok → empty
+  stdout + exit 0; human logs on stderr only.
+- **Rust unit:** parse RESULT lines; ignore non-matching stdout; whitelist filter.
+- **Integration (if feasible):** localhost remote run with forced fetch failure →
+  `deploy_failures` drives next-cycle whitelist.
+
+## Follow-ups (out of scope)
+
+- Soft-failure RESULT lines (`result\tsoft\t<repo>\t<reason>`).
+- Reason column on hard fails.
+- Feed local-watch the same report type.

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -37,3 +37,7 @@ else
 fi
 
 echo "Version set to $v in Cargo.toml/lock, core/check-push.sh and reference (docker)compose.yml"
+
+# continue to do the git actions
+git commit -as -m "bump version to $v"
+git tag -m "v${v}" "v${v}" -f

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ fn should_run_host_remote(
 /// Merge a remote check-push report into host-scoped `deploy_failures`.
 /// Only repos in this run's whitelist `W` are updated. Empty RESULT + exit 1
 /// (`exit_was_fail_with_empty_result`) marks all of `W` as failed.
-fn merge_deploy_failures(
+pub fn merge_deploy_failures(
     deploy_failures: &mut HashMap<String, HashSet<String>>,
     host_id: &str,
     whitelist: &HashSet<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,52 @@ fn should_run_host_remote(
             .any(|repo| failed_repos.contains(repo))
 }
 
+/// Merge a remote check-push report into host-scoped `deploy_failures`.
+/// Only repos in this run's whitelist `W` are updated. Empty RESULT + exit 1
+/// (`exit_was_fail_with_empty_result`) marks all of `W` as failed.
+fn merge_deploy_failures(
+    deploy_failures: &mut HashMap<String, HashSet<String>>,
+    host_id: &str,
+    whitelist: &HashSet<String>,
+    report: &ops::CheckPushReport,
+    exit_was_fail_with_empty_result: bool,
+) {
+    let entry = deploy_failures.entry(host_id.to_string()).or_default();
+    let failed: HashSet<String> = if exit_was_fail_with_empty_result {
+        whitelist.clone()
+    } else {
+        report
+            .failed_repos
+            .iter()
+            .filter(|r| whitelist.contains(*r))
+            .cloned()
+            .collect()
+    };
+    for repo in whitelist {
+        if failed.contains(repo) {
+            entry.insert(repo.clone());
+        } else {
+            entry.remove(repo);
+        }
+    }
+    if entry.is_empty() {
+        deploy_failures.remove(host_id);
+    }
+}
+
+/// Union probe `failed_repos` with this host's prior deploy failures.
+fn failure_set_for_host<'a>(
+    probe_failed: &'a HashSet<String>,
+    deploy_failures: &'a HashMap<String, HashSet<String>>,
+    host_id: &str,
+) -> HashSet<String> {
+    let mut s = probe_failed.clone();
+    if let Some(df) = deploy_failures.get(host_id) {
+        s.extend(df.iter().cloned());
+    }
+    s
+}
+
 /// Check config and remotes: validate SSH/git connectivity and repo existence on each host.
 pub fn run_check(config: &CentralConfig) -> Result<(), anyhow::Error> {
     let mut failures: Vec<String> = Vec::new();
@@ -302,6 +348,7 @@ fn run_prepare(config: &CentralConfig, ignore_missing: bool) -> Result<(), anyho
 fn run_cycle(
     config: &CentralConfig,
     last_remote_refs: &mut HashMap<String, String>,
+    deploy_failures: &mut HashMap<String, HashSet<String>>,
     round: u64,
     first_round: bool,
     skip_poll: bool,
@@ -338,6 +385,11 @@ fn run_cycle(
 
     let mut any_host_ran = false;
     let mut skipped_hosts: Vec<String> = Vec::new();
+    // Collect remote outcomes under a Mutex; merge into deploy_failures after scope.
+    let outcomes: std::sync::Mutex<
+        Vec<(String, HashSet<String>, Result<ops::CheckPushReport, anyhow::Error>)>,
+    > = std::sync::Mutex::new(Vec::new());
+
     std::thread::scope(|s| {
         for (host_id, host) in &config.hosts {
             let host_id = host_id.clone();
@@ -352,6 +404,15 @@ fn run_cycle(
             if !is_wildcard && host_repo_names.is_empty() {
                 continue;
             }
+
+            let host_failures = failure_set_for_host(&failed_repos, deploy_failures, &host_id);
+            let has_deploy_failure = host_repo_names
+                .iter()
+                .any(|repo| {
+                    deploy_failures
+                        .get(&host_id)
+                        .is_some_and(|df| df.contains(repo))
+                });
 
             // Wildcard hosts always run (we can't poll repos we don't know about).
             // Webhook-triggered cycles always run all hosts.
@@ -368,7 +429,7 @@ fn run_cycle(
                     first_round,
                     &host_repo_names,
                     &changed_repos,
-                    &failed_repos,
+                    &host_failures,
                 );
                 if !should_run {
                     skipped_hosts.push(host_id.clone());
@@ -376,6 +437,12 @@ fn run_cycle(
                 if has_probe_failure && !first_round && !has_changed_repo && should_run {
                     console::log_warning(format!(
                         "watch: host {{{}}} has probe failures, running remote check-push defensively",
+                        host_id
+                    ));
+                }
+                if has_deploy_failure && !first_round && !has_changed_repo && should_run {
+                    console::log_warning(format!(
+                        "watch: host {{{}}} has deploy failures, running remote check-push defensively",
                         host_id
                     ));
                 }
@@ -394,7 +461,7 @@ fn run_cycle(
                     host_repo_names
                         .iter()
                         .filter(|name| {
-                            changed_repos.contains(*name) || failed_repos.contains(*name)
+                            changed_repos.contains(*name) || host_failures.contains(*name)
                         })
                         .cloned()
                         .collect(),
@@ -402,6 +469,17 @@ fn run_cycle(
             } else {
                 None
             };
+            // Whitelist W used for merge: config aliases (same key space as probe failed_repos).
+            let whitelist_for_merge: HashSet<String> = match &effective_filter {
+                Some(f) => f.clone(),
+                None => host_repo_names.iter().cloned().collect(),
+            };
+            // RESULT lines use dir_name(); map back to config alias for deploy_failures.
+            let dir_to_name: HashMap<String, String> = config
+                .repos_for_host(&host_id)
+                .into_iter()
+                .map(|r| (r.dir_name().to_string(), r.name.clone()))
+                .collect();
             let (repo_whitelist, br_whitelist_per_host) =
                 whitelists_from_config(config, &host_id, effective_filter.as_ref());
             let check_push_env = ops::CheckPushEnv {
@@ -415,23 +493,50 @@ fn run_cycle(
             };
 
             any_host_ran = true;
+            let outcomes = &outcomes;
             s.spawn(move || {
-                // Task 3 wires CheckPushReport into deploy_failures; discard for now.
-                match ops::run_check_push_remote(
+                let result = ops::run_check_push_remote(
                     host,
                     &host_id,
                     &dir_base,
                     CHECK_PUSH_SCRIPT,
                     &check_push_env,
-                ) {
-                    Ok(_report) => {}
-                    Err(e) => {
-                        console::log_error(format!("Failed on {{{}}}: {}", host_id, e));
-                    }
+                )
+                .map(|report| ops::CheckPushReport {
+                    failed_repos: report
+                        .failed_repos
+                        .into_iter()
+                        .filter_map(|d| dir_to_name.get(&d).cloned())
+                        .collect(),
+                    exit_was_fail_with_empty_result: report.exit_was_fail_with_empty_result,
+                });
+                if let Err(ref e) = result {
+                    console::log_error(format!("Failed on {{{}}}: {}", host_id, e));
                 }
+                outcomes
+                    .lock()
+                    .unwrap()
+                    .push((host_id, whitelist_for_merge, result));
             });
         }
     });
+
+    for (host_id, whitelist, result) in outcomes.into_inner().unwrap() {
+        match result {
+            Ok(report) => {
+                merge_deploy_failures(
+                    deploy_failures,
+                    &host_id,
+                    &whitelist,
+                    &report,
+                    report.exit_was_fail_with_empty_result,
+                );
+            }
+            Err(_) => {
+                // SSH/infra failure: do not clear prior deploy_failures for this host.
+            }
+        }
+    }
 
     if any_host_ran && !skipped_hosts.is_empty() {
         console::log_info(format!("watch: skip {{{}}} (no remote repo changes)", skipped_hosts.join(", ")));
@@ -469,6 +574,7 @@ pub async fn run_watch(
     let deadline = opts.timeout_secs.map(|s| Instant::now() + Duration::from_secs(s));
     let mut round: u64 = 0;
     let mut last_remote_refs: HashMap<String, String> = HashMap::new();
+    let mut deploy_failures: HashMap<String, HashSet<String>> = HashMap::new();
     let mut first_timer_done = false;
 
     // Background version check: cache-gated, never blocks the loop, swallows
@@ -559,13 +665,24 @@ pub async fn run_watch(
         // run_cycle uses std::thread::scope (blocking SSH), so run in spawn_blocking
         let config_clone = config.clone();
         let mut refs = std::mem::take(&mut last_remote_refs);
+        let mut failures = std::mem::take(&mut deploy_failures);
         let trigger_label = trigger_label.to_string();
-        let returned_refs = tokio::task::spawn_blocking(move || {
-            run_cycle(&config_clone, &mut refs, round, first_round, skip_poll, &trigger_label, wh_tag);
-            refs
+        let (returned_refs, returned_failures) = tokio::task::spawn_blocking(move || {
+            run_cycle(
+                &config_clone,
+                &mut refs,
+                &mut failures,
+                round,
+                first_round,
+                skip_poll,
+                &trigger_label,
+                wh_tag,
+            );
+            (refs, failures)
         })
         .await?;
         last_remote_refs = returned_refs;
+        deploy_failures = returned_failures;
     }
 
     Ok(())
@@ -705,5 +822,51 @@ mod tests {
             &changed,
             &failed
         ));
+    }
+
+    #[test]
+    fn merge_deploy_failures_inserts_and_clears() {
+        let mut df = HashMap::new();
+        let wl: HashSet<_> = ["a", "b"].into_iter().map(String::from).collect();
+        let report = ops::CheckPushReport {
+            failed_repos: vec!["a".into()],
+            ..Default::default()
+        };
+        merge_deploy_failures(&mut df, "h1", &wl, &report, false);
+        assert_eq!(df.get("h1").unwrap(), &HashSet::from(["a".into()]));
+        let report_ok = ops::CheckPushReport {
+            failed_repos: vec![],
+            ..Default::default()
+        };
+        merge_deploy_failures(&mut df, "h1", &wl, &report_ok, false);
+        assert!(df.get("h1").is_none());
+    }
+
+    #[test]
+    fn merge_deploy_failures_empty_result_marks_whitelist() {
+        let mut df = HashMap::new();
+        let wl: HashSet<_> = ["a", "b"].into_iter().map(String::from).collect();
+        let report = ops::CheckPushReport {
+            failed_repos: vec![],
+            ..Default::default()
+        };
+        merge_deploy_failures(&mut df, "h1", &wl, &report, true);
+        assert_eq!(df.get("h1").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn failure_set_for_host_unions_probe_and_deploy() {
+        let probe: HashSet<_> = ["a".into()].into_iter().collect();
+        let mut df = HashMap::new();
+        df.insert(
+            "h1".into(),
+            ["b".into()].into_iter().collect::<HashSet<_>>(),
+        );
+        let union = failure_set_for_host(&probe, &df, "h1");
+        assert_eq!(union, HashSet::from(["a".into(), "b".into()]));
+        assert_eq!(
+            failure_set_for_host(&probe, &df, "other"),
+            HashSet::from(["a".into()])
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,9 @@ fn poll_changed_repos(
             }
             Err(e) => {
                 console::log_warning(format!("polling failed for repo [{}]: {}", repo_name, e));
-                failed_repos.insert(repo_name);
+                failed_repos.insert(repo_name.clone());
+                // Clear the up-to-date status so the repo is retried in the next cycle
+                last_refs.remove(&repo_name);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,14 +416,18 @@ fn run_cycle(
 
             any_host_ran = true;
             s.spawn(move || {
-                if let Err(e) = ops::run_check_push_remote(
+                // Task 3 wires CheckPushReport into deploy_failures; discard for now.
+                match ops::run_check_push_remote(
                     host,
                     &host_id,
                     &dir_base,
                     CHECK_PUSH_SCRIPT,
                     &check_push_env,
                 ) {
-                    console::log_error(format!("Failed on {{{}}}: {}", host_id, e));
+                    Ok(_report) => {}
+                    Err(e) => {
+                        console::log_error(format!("Failed on {{{}}}: {}", host_id, e));
+                    }
                 }
             });
         }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -221,6 +221,9 @@ fn build_check_push_extra_env(env: &CheckPushEnv) -> String {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CheckPushReport {
     pub failed_repos: Vec<String>,
+    /// True when remote exited 1 with no RESULT lines (unknown worker failure).
+    /// Caller should mark all repos in this run's whitelist as failed.
+    pub exit_was_fail_with_empty_result: bool,
 }
 
 /// Parse machine RESULT lines from check-push stdout (`result\tfail\t<repo>`).
@@ -243,6 +246,7 @@ pub fn parse_check_push_result(stdout: &str) -> CheckPushReport {
     }
     CheckPushReport {
         failed_repos: set.into_iter().collect(),
+        exit_was_fail_with_empty_result: false,
     }
 }
 
@@ -276,13 +280,13 @@ pub fn run_check_push_remote(
     );
     let (status, stdout) = ssh::ssh_run_inherit_stderr_capture_stdout(host, &command, script.as_bytes())
         .context("run check-push on remote failed")?;
-    let report = parse_check_push_result(&stdout);
+    let mut report = parse_check_push_result(&stdout);
     if status.success() {
         return Ok(report);
     }
     let code = status.code().unwrap_or(1);
     if code == 1 {
-        // Caller may expand empty report to full whitelist.
+        report.exit_was_fail_with_empty_result = report.failed_repos.is_empty();
         return Ok(report);
     }
     anyhow::bail!("ssh exited with {}: {}", status, stdout.trim())

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -217,16 +217,48 @@ fn build_check_push_extra_env(env: &CheckPushEnv) -> String {
     }
 }
 
+/// Report of hard-failed repos from a remote check-push run.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CheckPushReport {
+    pub failed_repos: Vec<String>,
+}
+
+/// Parse machine RESULT lines from check-push stdout (`result\tfail\t<repo>`).
+/// Ignores noise; returns sorted unique repo names.
+pub fn parse_check_push_result(stdout: &str) -> CheckPushReport {
+    let mut set = BTreeSet::new();
+    for line in stdout.lines() {
+        let mut parts = line.split('\t');
+        if parts.next() != Some("result") {
+            continue;
+        }
+        if parts.next() != Some("fail") {
+            continue;
+        }
+        if let Some(repo) = parts.next() {
+            if !repo.is_empty() && parts.next().is_none() {
+                set.insert(repo.to_string());
+            }
+        }
+    }
+    CheckPushReport {
+        failed_repos: set.into_iter().collect(),
+    }
+}
+
 /// Run the embedded check-push.sh script on the remote host with sandbox env.
 /// dir_base is the host's work dir (e.g. /work); script runs with DIR_BASE set and --once.
 /// env supplies REPO_WHITELIST, BR_WHITELIST_PER_REPO, RELEASE_TAG_* when set.
+///
+/// Exit 0 / 1 both return `Ok(CheckPushReport)` (caller may expand empty exit-1
+/// report to full whitelist). Other non-zero exits are infrastructure errors.
 pub fn run_check_push_remote(
     host: &Host,
     host_id: &str,
     dir_base: &Path,
     script: &str,
     env: &CheckPushEnv,
-) -> Result<()> {
+) -> Result<CheckPushReport> {
     let dir_base_esc = escape_single_quoted(&dir_base.to_string_lossy());
     let host_id_esc = escape_single_quoted(host_id);
     let extra = build_check_push_extra_env(env);
@@ -242,8 +274,18 @@ pub fn run_check_push_remote(
         if console::color_enabled() { " FORCE_COLOR=1" } else { "" },
         extra
     );
-    ssh::ssh_run_with_stdin(host, &command, script.as_bytes())
-        .context("run check-push on remote failed")
+    let (status, stdout) = ssh::ssh_run_inherit_stderr_capture_stdout(host, &command, script.as_bytes())
+        .context("run check-push on remote failed")?;
+    let report = parse_check_push_result(&stdout);
+    if status.success() {
+        return Ok(report);
+    }
+    let code = status.code().unwrap_or(1);
+    if code == 1 {
+        // Caller may expand empty report to full whitelist.
+        return Ok(report);
+    }
+    anyhow::bail!("ssh exited with {}: {}", status, stdout.trim())
 }
 
 /// Run the embedded check-push.sh script once on the local machine.
@@ -388,5 +430,24 @@ mod tests {
         };
 
         assert_eq!(normalize(a), normalize(b));
+    }
+
+    #[test]
+    fn parse_check_push_result_collects_fail_lines() {
+        let stdout = "result\tfail\trepo-a\nresult\tfail\trepo-b\n";
+        let report = parse_check_push_result(stdout);
+        assert_eq!(report.failed_repos, vec!["repo-a", "repo-b"]);
+    }
+
+    #[test]
+    fn parse_check_push_result_ignores_noise_and_dedups() {
+        let stdout = "hello\nresult\tfail\tx\nresult\tfail\tx\n";
+        let report = parse_check_push_result(stdout);
+        assert_eq!(report.failed_repos, vec!["x"]);
+    }
+
+    #[test]
+    fn parse_check_push_result_empty() {
+        assert!(parse_check_push_result("").failed_repos.is_empty());
     }
 }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::io::{Read, Write};
+use std::process::{Command, ExitStatus, Stdio};
 
 use crate::config::Host;
 
@@ -118,6 +118,41 @@ pub fn ssh_run_with_stdin(host: &Host, command: &str, stdin_data: &[u8]) -> Resu
     }
 }
 
+/// Pipe stdin; inherit stderr (live logs); capture stdout.
+///
+/// Does not auto-bail on non-zero exit — caller interprets status and RESULT lines.
+/// Uses an explicit stdout reader thread because `wait_with_output` requires piped
+/// stderr and would conflict with inherited live logs.
+pub fn ssh_run_inherit_stderr_capture_stdout(
+    host: &Host,
+    command: &str,
+    stdin_data: &[u8],
+) -> Result<(ExitStatus, String)> {
+    let mut cmd = build_ssh_command(host)?;
+    cmd.arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    let mut child = cmd.spawn().context("Failed to execute ssh")?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(stdin_data)
+            .context("Failed to write ssh stdin")?;
+    }
+    let mut stdout_pipe = child
+        .stdout
+        .take()
+        .context("Failed to take ssh stdout pipe")?;
+    let handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        Read::read_to_string(&mut stdout_pipe, &mut buf).ok();
+        buf
+    });
+    let status = child.wait().context("Failed to wait for ssh")?;
+    let stdout = handle.join().unwrap_or_default();
+    Ok((status, stdout))
+}
+
 /// Run `command` on `host` with `stdin_data` piped in; capture stdout and stderr.
 /// Returns captured stdout on success. On non-zero exit, `Err` includes the status
 /// code and trimmed stderr in its message.
@@ -209,5 +244,19 @@ mod tests {
         let s = err.to_string();
         assert!(s.contains("7"), "exit code in error: {}", s);
         assert!(s.contains("boom"), "stderr in error: {}", s);
+    }
+
+    #[test]
+    fn inherit_stderr_capture_stdout_localhost() {
+        let h = host("localhost");
+        // Use printf (portable): localhost path is `sh -lc`, and dash lacks $'\t'.
+        let (status, out) = ssh_run_inherit_stderr_capture_stdout(
+            &h,
+            "echo err >&2; printf 'result\\tfail\\tr1\\n'; exit 1",
+            b"",
+        )
+        .unwrap();
+        assert!(!status.success());
+        assert!(out.contains("result\tfail\tr1"));
     }
 }

--- a/tests/integration_check_push_result.rs
+++ b/tests/integration_check_push_result.rs
@@ -1,0 +1,51 @@
+//! Smoke test for check-push RESULT protocol: parse stdout → merge deploy_failures.
+//! Canned data mirrors `core/tests/scripts/test-check-push-result.sh` (badrepo hard fail).
+
+use git_supervisor::merge_deploy_failures;
+use git_supervisor::ops::{parse_check_push_result, CheckPushReport};
+use std::collections::{HashMap, HashSet};
+
+#[test]
+fn parse_and_merge_preserves_failed_repo_across_cycles() {
+    let stdout = "result\tfail\tbadrepo\n";
+    let report = parse_check_push_result(stdout);
+    assert_eq!(report.failed_repos, vec!["badrepo"]);
+
+    let whitelist: HashSet<_> = ["badrepo".into()].into_iter().collect();
+    let mut deploy_failures = HashMap::new();
+
+    merge_deploy_failures(&mut deploy_failures, "local", &whitelist, &report, false);
+    assert_eq!(
+        deploy_failures.get("local").unwrap(),
+        &HashSet::from(["badrepo".into()])
+    );
+
+    // Second watch-cycle merge with the same failure report keeps deploy_failures populated.
+    merge_deploy_failures(&mut deploy_failures, "local", &whitelist, &report, false);
+    assert!(
+        deploy_failures
+            .get("local")
+            .unwrap()
+            .contains("badrepo"),
+        "failed repo should remain after second merge"
+    );
+
+    let report_ok = CheckPushReport::default();
+    merge_deploy_failures(&mut deploy_failures, "local", &whitelist, &report_ok, false);
+    assert!(deploy_failures.get("local").is_none());
+}
+
+#[test]
+fn parse_and_merge_empty_result_exit_fail_marks_whitelist() {
+    let report = parse_check_push_result("");
+    assert!(report.failed_repos.is_empty());
+
+    let whitelist: HashSet<_> = ["badrepo".into(), "other".into()].into_iter().collect();
+    let mut deploy_failures = HashMap::new();
+
+    merge_deploy_failures(&mut deploy_failures, "local", &whitelist, &report, true);
+    assert_eq!(deploy_failures.get("local").unwrap().len(), 2);
+
+    merge_deploy_failures(&mut deploy_failures, "local", &whitelist, &report, true);
+    assert_eq!(deploy_failures.get("local").unwrap().len(), 2);
+}


### PR DESCRIPTION
## Summary
- `check-push.sh` emits `result\tfail\t<repo>` on stdout for hard failures, moves human logs to stderr, and exits 1 on `--once` when any worker fails
- Controller captures RESULT lines while streaming stderr live, returning `CheckPushReport`
- Watch loop keeps host-scoped `deploy_failures` across cycles and unions them with `ls-remote` probe failures for retry/whitelist decisions

## Test plan
- [ ] `bash core/tests/scripts/test-check-push-result.sh`
- [ ] `cargo test --lib`
- [ ] `cargo test --test integration_check_push_result`
- [ ] Manual: force a fetch failure on one host repo; confirm next timer cycle retries that repo only (or at least includes it in whitelist)


Made with [Cursor](https://cursor.com)